### PR TITLE
Use /usr/bin/python3 if available

### DIFF
--- a/bin/anoise
+++ b/bin/anoise
@@ -1,3 +1,7 @@
 #!/bin/bash
-python3 /usr/share/anoise/anoise.py
+if [ -x /usr/bin/python3 ] ; then
+    /usr/bin/python3 /usr/share/anoise/anoise.py
+else
+    python3 /usr/share/anoise/anoise.py
+fi
 


### PR DESCRIPTION
Use the system python (if installed in /usr/bin) even if the user has another python in the path (for instance, they are using pyenv).  This avoids module dependency problems when installing with the .deb but a user python is in the path ahead of the system python.